### PR TITLE
Allows ci to override version from environment

### DIFF
--- a/ci
+++ b/ci
@@ -2,14 +2,20 @@
 
 echo "Swift 3 Continuous Integration";
 
-# Determine version
-VERSION_FILE=".swift-version"
-if [ ! -f $VERSION_FILE ]; 
+# Determine version from environment variable or swiftenv file
+if [[ ! -z $SWIFT_VERSION ]]
 then
-    echo "No .swift-version file found."
-    exit 1
+    VERSION = $SWIFT_VERSION
+else
+    VERSION_FILE=".swift-version"
+    if [ ! -f $VERSION_FILE ]; 
+    then
+        echo "No SWIFT_VERSION environment variable or .swift-version file found."
+        exit 1
+    fi
+    VERSION=`cat $VERSION_FILE | tr -d '[[:space:]]'`
 fi
-VERSION=`cat $VERSION_FILE | tr -d '[[:space:]]'`
+
 echo "📅 Version: $VERSION";
 
 # Determine OS
@@ -43,6 +49,7 @@ sudo apt-get install -y clang libicu-dev uuid-dev
 
 echo "🐦 Installing Swift";
 swiftenv install $VERSION;
+swiftenv local $VERSION;
 
 echo "🚀 Building";
 swift build


### PR DESCRIPTION
With the frequency of Swift releases, plus Turnstile + Perfect integration, I want to make sure that Turnstile works on mutliple swift versions.

This allows someone to override the `.swift-version` file with a `SWIFT_VERSION` environment variable, so you can use it in multiple builds. 

See https://travis-ci.org/stormpath/Turnstile/builds/155228000 as an example build
